### PR TITLE
Feature/introduce general rate limiting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,9 +22,9 @@ func TTLEmailVerificationToken() time.Duration {
 }
 
 func RateLimitRegister() time.Duration {
-	return time.Minute
+	return 24 * time.Hour
 }
 
 func RateLimitRequestOTP() time.Duration {
-	return time.Minute
+	return 15 * time.Minute
 }

--- a/config/database/database_config.go
+++ b/config/database/database_config.go
@@ -1,7 +1,6 @@
 package database_config
 
 import (
-	"context"
 	"fmt"
 	"os"
 	auth_service "qolboard-api/services/auth"
@@ -17,19 +16,8 @@ var (
 	dbPriv *sqlx.DB
 )
 
-func debugCurrentUser() {
-	ctx := context.Background()
-	var currentUser string
-	if err := db.QueryRowContext(ctx, "SELECT current_user").Scan(&currentUser); err != nil {
-		logging.LogError("database_config", "failed to get current user: %v", err)
-	} else {
-		logging.LogInfo("database_config", "current_user", currentUser)
-	}
-}
-
 // If c is not null, get_user_uuid() postgres function will be available to get the authenticated user UUID
 func DB(c *gin.Context) (*sqlx.Tx, error) {
-	debugCurrentUser()
 	return beginDbTransaction(c)
 }
 

--- a/main.go
+++ b/main.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"os"
+	"os/signal"
 	"qolboard-api/config"
 	"qolboard-api/controllers"
 	"qolboard-api/services/email"
 	"qolboard-api/services/logging"
+	"syscall"
+	"time"
 
 	database_config "qolboard-api/config/database"
 	canvas_controller "qolboard-api/controllers/canvas"
@@ -16,6 +21,7 @@ import (
 	auth_middleware "qolboard-api/middleware/auth"
 	cors_middleware "qolboard-api/middleware/cors"
 	error_middleware "qolboard-api/middleware/error"
+	rate_limiting_middleware "qolboard-api/middleware/rate_limiting"
 	response_middleware "qolboard-api/middleware/response"
 	error_service "qolboard-api/services/error"
 
@@ -39,7 +45,9 @@ func init() {
 func main() {
 	gin.SetMode(os.Getenv("GIN_MODE"))
 
-	ctx := context.Background()
+	// Create context that listens for the interrupt signal from the OS.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	// Setup email client
 	fromEmail := "info@qolboard.com"
@@ -65,11 +73,16 @@ func main() {
 
 	// Runs before
 	r.Use(cors_middleware.Run)
+	r.Use(rate_limiting_middleware.RunRateLimitIP(ctx))
 
 	// Runs after (define in reverse)
 	r.Use(response_middleware.Run)
 	r.Use(error_middleware.Run)
 
+	// Handle unregistered routes or methods
+	r.NoRoute(func(c *gin.Context) {
+		c.AbortWithError(404, fmt.Errorf("not found"))
+	})
 	// Define unauthenticated routes routes
 	// Auth routes
 	rAuth := r.Group("/auth")
@@ -86,6 +99,7 @@ func main() {
 	{
 		// User middleware
 		rUser.Use(auth_middleware.Run)
+		rUser.Use(rate_limiting_middleware.RunRateLimitUser(ctx))
 
 		rUser.GET("", user_controller.Get)
 		rUser.POST("/logout", restHandler.Logout)
@@ -109,17 +123,43 @@ func main() {
 		rUser.GET("/ws/canvas/:id", canvas_controller.Websocket)
 	}
 
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%s", os.Getenv("PORT")),
+		Handler: r,
+	}
+
 	// Listen and serve router
 	logging.LogInfo("main", "Running server", 0)
 
-	var err error
-	if config.IsDev() {
-		err = r.Run()
-	} else {
-		err = autotls.Run(r, os.Getenv("API_DOMAIN"))
+	// Initializing the server in a goroutine so that it won't block the graceful shutdown handling below
+	go func() {
+		var err error
+		if config.IsDev() {
+			// err = r.Run()
+			err = srv.ListenAndServe()
+		} else {
+			// err = autotls.Run(r, os.Getenv("API_DOMAIN"))
+			err = autotls.Run(srv.Handler, os.Getenv("API_DOMAIN"))
+		}
+		if err != nil && err != http.ErrServerClosed {
+			logging.LogError("main", "Error running server", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Listen for the interrupt signal.
+	<-ctx.Done()
+
+	// Restore default behavior on the interrupt signal and notify user of shutdown.
+	stop()
+	logging.LogInfo("main", "shutting down gracefully, press Ctrl+C again to force", nil)
+
+	// The context is used to inform the server it now has a timeout to finish any processing/handling
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		logging.LogInfo("main", "server shutdown", err)
 	}
-	if err != nil {
-		logging.LogError("main", "Error running server", err)
-		os.Exit(1)
-	}
+
+	logging.LogInfo("main", "server finished, exiting", nil)
 }

--- a/middleware/rate_limiting/rate_limiting.go
+++ b/middleware/rate_limiting/rate_limiting.go
@@ -1,0 +1,94 @@
+package rate_limiting_middleware
+
+import (
+	"context"
+	"net/http"
+	auth_service "qolboard-api/services/auth"
+	"qolboard-api/services/logging"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+type client struct {
+	limiter *rate.Limiter
+}
+
+type RateLimiter struct {
+	name    string
+	mu      sync.Mutex
+	clients map[string]*client
+}
+
+// PeriodicCleanup starts a background goroutine for periodic cleanups
+func (rl *RateLimiter) PeriodicClientsCleanup(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop() // Ensure ticker channel is closed on exit
+
+	for {
+		select {
+		case <-ticker.C:
+			rl.mu.Lock()
+			for key, c := range rl.clients {
+				if c.limiter.Allow() {
+					delete(rl.clients, key)
+				}
+			}
+			rl.mu.Unlock()
+		case <-ctx.Done():
+			logging.LogInfo("rate_limiting_middleware", "ctx done, finishing", nil)
+			return // Exit when context is canceled
+		}
+	}
+}
+
+func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter *rate.Limiter) {
+	rl.mu.Lock()
+	if _, exists := rl.clients[clientKey]; !exists {
+		// allow x number of requests per rate, for each clinetKey
+		rl.clients[clientKey] = &client{limiter: limiter}
+	}
+	cl := rl.clients[clientKey]
+	rl.mu.Unlock()
+
+	if !cl.limiter.Allow() {
+		logging.LogInfo("rate_limiting_middleware", "rate limit exceeded", map[string]any{
+			"rate_limiter_name": rl.name,
+		})
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+			"error": "rate limit exceeded",
+		})
+	}
+}
+
+func RunRateLimitIP(ctx context.Context) gin.HandlerFunc {
+	rl := RateLimiter{
+		name:    "ip",
+		clients: make(map[string]*client),
+	}
+
+	go rl.PeriodicClientsCleanup(ctx, 1*time.Minute)
+
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		rl.RateLimitClient(c, ip, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an ip
+		c.Next()
+	}
+}
+
+func RunRateLimitUser(ctx context.Context) gin.HandlerFunc {
+	rl := RateLimiter{
+		name:    "user",
+		clients: make(map[string]*client),
+	}
+
+	go rl.PeriodicClientsCleanup(ctx, 1*time.Minute)
+
+	return func(c *gin.Context) {
+		id := auth_service.Auth(c)
+		rl.RateLimitClient(c, id, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an authenticated user
+		c.Next()
+	}
+}


### PR DESCRIPTION
General rate limiting added on all endpoints
- All endpoints have IP based rate limiting
- All authenticated endpoints have rate limiting based on the authenticated user (because IP rate limiting can easily be overcome if the user is determined)