### PR TITLE
Fix/consistent response errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,8 @@ func main() {
 
 	// Handle unregistered routes or methods
 	r.NoRoute(func(c *gin.Context) {
-		c.AbortWithError(404, fmt.Errorf("not found"))
+		error_service.PublicError(c, "Not found.", http.StatusNotFound, "", "", "")
+		c.Abort()
 	})
 	// Define unauthenticated routes routes
 	// Auth routes

--- a/main.go
+++ b/main.go
@@ -71,13 +71,13 @@ func main() {
 
 	// Global middleware
 
+	// Runs after (define in reverse). We define before other middleware so that these can execute even if other middleware call c.Abort()
+	r.Use(response_middleware.Run)
+	r.Use(error_middleware.Run)
+
 	// Runs before
 	r.Use(cors_middleware.Run)
 	r.Use(rate_limiting_middleware.RunRateLimitIP(ctx))
-
-	// Runs after (define in reverse)
-	r.Use(response_middleware.Run)
-	r.Use(error_middleware.Run)
 
 	// Handle unregistered routes or methods
 	r.NoRoute(func(c *gin.Context) {

--- a/middleware/auth/auth_middleware.go
+++ b/middleware/auth/auth_middleware.go
@@ -11,6 +11,7 @@ import (
 
 // Authenticate middleware
 func Run(c *gin.Context) {
+	logging.LogDebug("[middleware]", "[auth]", nil)
 	unauthorized := false
 
 	token, err := auth_service.GetJWTCookie(c)

--- a/middleware/cors/cors_middleware.go
+++ b/middleware/cors/cors_middleware.go
@@ -18,7 +18,7 @@ func Run(c *gin.Context) {
 	c.Writer.Header().Set("Access-Control-Allow-Methods", "OPTIONS, GET, POST, PUT, DELETE")
 
 	if c.Request.Method == http.MethodOptions {
-		c.AbortWithStatus(http.StatusContinue)
+		c.AbortWithStatus(http.StatusNoContent)
 	}
 
 	c.Next()

--- a/middleware/cors/cors_middleware.go
+++ b/middleware/cors/cors_middleware.go
@@ -3,11 +3,13 @@ package cors_middleware
 import (
 	"net/http"
 	"os"
+	"qolboard-api/services/logging"
 
 	"github.com/gin-gonic/gin"
 )
 
 func Run(c *gin.Context) {
+	logging.LogDebug("[middleware]", "[cors]", nil)
 	var appHost string = os.Getenv("APP_HOST")
 
 	c.Writer.Header().Set("Access-Control-Allow-Origin", appHost)

--- a/middleware/error/error_middleware.go
+++ b/middleware/error/error_middleware.go
@@ -3,6 +3,7 @@ package error_middleware
 import (
 	"net/http"
 	error_service "qolboard-api/services/error"
+	"qolboard-api/services/logging"
 	response_service "qolboard-api/services/response"
 
 	"github.com/gin-gonic/gin"
@@ -17,6 +18,7 @@ type Error struct {
 func Run(c *gin.Context) {
 	c.Next()
 
+	logging.LogDebug("[middleware]", "[error]", nil)
 	var errors []*error_service.Error = make([]*error_service.Error, 0)
 	var code int = 500
 
@@ -55,4 +57,3 @@ func Run(c *gin.Context) {
 		"errors": errors,
 	})
 }
-

--- a/middleware/rate_limiting/rate_limiting.go
+++ b/middleware/rate_limiting/rate_limiting.go
@@ -6,7 +6,6 @@ import (
 	auth_service "qolboard-api/services/auth"
 	error_service "qolboard-api/services/error"
 	"qolboard-api/services/logging"
-	response_service "qolboard-api/services/response"
 	"sync"
 	"time"
 
@@ -46,7 +45,7 @@ func (rl *RateLimiter) PeriodicClientsCleanup(ctx context.Context, interval time
 	}
 }
 
-func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter *rate.Limiter) bool {
+func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter *rate.Limiter) {
 	rl.mu.Lock()
 	if _, exists := rl.clients[clientKey]; !exists {
 		// allow x number of requests per rate, for each clinetKey
@@ -54,24 +53,16 @@ func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter
 	}
 	cl := rl.clients[clientKey]
 	rl.mu.Unlock()
-
 	if !cl.limiter.Allow() {
 		logging.LogInfo("rate_limiting_middleware", "rate limit exceeded", map[string]any{
 			"rate_limiter_name": rl.name,
 		})
 		error_service.PublicError(c, "Rate limit exceeded.", http.StatusTooManyRequests, "", "", "")
-		response_service.SetCode(c, http.StatusTooManyRequests)
 		c.Abort()
-		return false
 	}
-
-	return true
 }
 
 func RunRateLimitIP(ctx context.Context) gin.HandlerFunc {
-	error_service.PublicError(ctx, "Rate limit exceeded.", http.StatusTooManyRequests, "", "", "")
-	// response_service.SetCode(c, http.StatusTooManyRequests)
-	ctx.Abort()
 	rl := RateLimiter{
 		name:    "ip",
 		clients: make(map[string]*client),
@@ -80,11 +71,10 @@ func RunRateLimitIP(ctx context.Context) gin.HandlerFunc {
 	go rl.PeriodicClientsCleanup(ctx, 1*time.Minute)
 
 	return func(c *gin.Context) {
+		logging.LogDebug("[middleware]", "[rate_limiting]->[RunRateLimitIP]", nil)
 		ip := c.ClientIP()
-		allow := rl.RateLimitClient(c, ip, rate.NewLimiter(rate.Every(20*time.Second), 10)) // max 10 requests per second for an ip
-		if allow {
-			c.Next()
-		}
+		rl.RateLimitClient(c, ip, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an ip
+		c.Next()
 	}
 }
 
@@ -97,10 +87,9 @@ func RunRateLimitUser(ctx context.Context) gin.HandlerFunc {
 	go rl.PeriodicClientsCleanup(ctx, 1*time.Minute)
 
 	return func(c *gin.Context) {
+		logging.LogDebug("[middleware]", "[rate_limiting]->[RunRateLimitUser]", nil)
 		id := auth_service.Auth(c)
-		allow := rl.RateLimitClient(c, id, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an authenticated user
-		if allow {
-			c.Next()
-		}
+		rl.RateLimitClient(c, id, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an authenticated user
+		c.Next()
 	}
 }

--- a/middleware/rate_limiting/rate_limiting.go
+++ b/middleware/rate_limiting/rate_limiting.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"net/http"
 	auth_service "qolboard-api/services/auth"
+	error_service "qolboard-api/services/error"
 	"qolboard-api/services/logging"
+	response_service "qolboard-api/services/response"
 	"sync"
 	"time"
 
@@ -44,7 +46,7 @@ func (rl *RateLimiter) PeriodicClientsCleanup(ctx context.Context, interval time
 	}
 }
 
-func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter *rate.Limiter) {
+func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter *rate.Limiter) bool {
 	rl.mu.Lock()
 	if _, exists := rl.clients[clientKey]; !exists {
 		// allow x number of requests per rate, for each clinetKey
@@ -57,13 +59,19 @@ func (rl *RateLimiter) RateLimitClient(c *gin.Context, clientKey string, limiter
 		logging.LogInfo("rate_limiting_middleware", "rate limit exceeded", map[string]any{
 			"rate_limiter_name": rl.name,
 		})
-		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
-			"error": "rate limit exceeded",
-		})
+		error_service.PublicError(c, "Rate limit exceeded.", http.StatusTooManyRequests, "", "", "")
+		response_service.SetCode(c, http.StatusTooManyRequests)
+		c.Abort()
+		return false
 	}
+
+	return true
 }
 
 func RunRateLimitIP(ctx context.Context) gin.HandlerFunc {
+	error_service.PublicError(ctx, "Rate limit exceeded.", http.StatusTooManyRequests, "", "", "")
+	// response_service.SetCode(c, http.StatusTooManyRequests)
+	ctx.Abort()
 	rl := RateLimiter{
 		name:    "ip",
 		clients: make(map[string]*client),
@@ -73,8 +81,10 @@ func RunRateLimitIP(ctx context.Context) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		ip := c.ClientIP()
-		rl.RateLimitClient(c, ip, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an ip
-		c.Next()
+		allow := rl.RateLimitClient(c, ip, rate.NewLimiter(rate.Every(20*time.Second), 10)) // max 10 requests per second for an ip
+		if allow {
+			c.Next()
+		}
 	}
 }
 
@@ -88,7 +98,9 @@ func RunRateLimitUser(ctx context.Context) gin.HandlerFunc {
 
 	return func(c *gin.Context) {
 		id := auth_service.Auth(c)
-		rl.RateLimitClient(c, id, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an authenticated user
-		c.Next()
+		allow := rl.RateLimitClient(c, id, rate.NewLimiter(rate.Every(1*time.Second), 10)) // max 10 requests per second for an authenticated user
+		if allow {
+			c.Next()
+		}
 	}
 }

--- a/middleware/response/response_middleware.go
+++ b/middleware/response/response_middleware.go
@@ -11,5 +11,7 @@ func Run(c *gin.Context) {
 	c.Next()
 
 	logging.LogDebug("[middleware]", "[response]", nil)
-	response_service.Response(c)
+	if !c.Writer.Written() || true {
+		response_service.Response(c)
+	}
 }

--- a/middleware/response/response_middleware.go
+++ b/middleware/response/response_middleware.go
@@ -11,7 +11,7 @@ func Run(c *gin.Context) {
 	c.Next()
 
 	logging.LogDebug("[middleware]", "[response]", nil)
-	if !c.Writer.Written() || true {
+	if !c.Writer.Written() {
 		response_service.Response(c)
 	}
 }

--- a/middleware/response/response_middleware.go
+++ b/middleware/response/response_middleware.go
@@ -1,6 +1,7 @@
 package response_middleware
 
 import (
+	"qolboard-api/services/logging"
 	response_service "qolboard-api/services/response"
 
 	"github.com/gin-gonic/gin"
@@ -9,5 +10,6 @@ import (
 func Run(c *gin.Context) {
 	c.Next()
 
+	logging.LogDebug("[middleware]", "[response]", nil)
 	response_service.Response(c)
 }

--- a/services/response/response_service.go
+++ b/services/response/response_service.go
@@ -107,8 +107,3 @@ func Response(c *gin.Context) {
 
 	c.JSON(code, response)
 }
-
-func Abort(c *gin.Context) {
-	Response(c)
-	panic(1)
-}


### PR DESCRIPTION
- (fix/response) Standardize the non-standard error responses that were being used for `rate limit exceeded` and `route not found`
  - This required fixing a bug: Register error and response middlewares (these two runs after request lifecycle) to be registered before other middleware, so that they will still run in the event that another middleware calls `c.Abort()`
- (logging) Add debug logging for each middleware